### PR TITLE
Replace print statements with Loguru logging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
   "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
   "Operating System :: OS Independent",
 ]
-dependencies = ["lazy_ci","flask"]
+dependencies = ["lazy_ci","flask", "loguru"]
 dynamic = ["version"]
 
 [project.scripts]

--- a/src/conways_game_of_war/game_state.py
+++ b/src/conways_game_of_war/game_state.py
@@ -1,4 +1,5 @@
 """Conway's game of life but with some extra sauce to enable WAR!"""
+from loguru import logger
 
 DEFAULT_BOARD_SIZE_X = 127
 DEFAULT_BOARD_SIZE_Y = 131
@@ -90,7 +91,7 @@ class GameState:
                         (y + j) % self.board_size_y
                     ]
                     if neighbor_cell.alive and neighbor_cell.owner is not None and neighbor_cell.owner != player:
-                        print(f"Player {player} is fighting player {neighbor_cell.owner}")
+                        logger.info(f"Player {player} is fighting player {neighbor_cell.owner}")
                         neighbor_cell.alive = False
                         self.board[x][y].alive = False
                         return True


### PR DESCRIPTION
Related to #1

This pull request introduces Loguru as a logging framework in the `conways_game_of_war` project, enhancing the logging mechanism within the game's state management.

- **Dependency Addition**: Adds "loguru" to the `dependencies` list in `pyproject.toml`, ensuring the package is installed with the project.
- **Logging Integration**: Replaces a `print` statement with a Loguru `logger.info` call in `src/conways_game_of_war/game_state.py`. This change is made within the `fight_unfriendly_neighbors` function, improving the logging of player interactions during the game.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/calvinloveland/conway_game_of_war/issues/1?shareId=3d6c0a80-7985-45bc-b3e8-24600afc57f6).